### PR TITLE
Add header and footer fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased] - XXXX-XX-XX
 - Add support for string markers and string streams ([#2](https://github.com/cbrnr/XDF.jl/pull/2) by [Alberto Barradas](https://github.com/abcsds) and [Clemens Brunner](https://github.com/cbrnr))
+- Make header and footer XML available in "xml" key ([#4](https://github.com/cbrnr/XDF.jl/pull/4) by [Alberto Barradas](https://github.com/abcsds))
 
 ## [0.1.0] - 2020-09-25
 ### Added

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ streams = read_xdf("minimal.xdf")
 This package is currently in an early stage, so here's an overview of what doesn't work (yet):
 
 - [ ] Time synchronization (via linear regression) is always performed, this will be changed to an optional parameter
-- [ ] The complete XML headers and footers of streams are not yet available in the output
+- [x] The complete XML headers and footers of streams are not yet available in the output
 - [ ] Dejittering of streams with regular sampling rates is not available yet
 - [ ] Loading only specific streams does not work yet
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ streams = read_xdf("minimal.xdf")
 ## Current status
 This package is currently in an early stage, so here's an overview of what doesn't work (yet):
 
-- [ ] Time synchronization (via linear regression) is always performed, this will be changed to an optional parameter
-- [x] The complete XML headers and footers of streams are not yet available in the output
 - [ ] Dejittering of streams with regular sampling rates is not available yet
 - [ ] Loading only specific streams does not work yet
 

--- a/src/XDF.jl
+++ b/src/XDF.jl
@@ -56,21 +56,13 @@ function read_xdf(filename::AbstractString, sync::Bool=true)
             elseif tag == 2  # StreamHeader
                 xml = String(read(io, len))
                 @debug "    $xml"
-                # Add header data to stream dictionary
                 streams[id] = Dict(
                     "name" => findtag(xml, "name"),
                     "type" => findtag(xml, "type"),
                     "nchannels" => findtag(xml, "channel_count", Int),
                     "srate" => findtag(xml, "nominal_srate", Float32),
                     "dtype" => DATA_TYPE[findtag(xml, "channel_format")],
-                    "source_id" => findtag(xml, "source_id"),
-                    "version" => findtag(xml, "version"),
-                    "created_at" => findtag(xml, "created_at"),
-                    "uid" => findtag(xml, "uid"),
-                    "session_id" => findtag(xml, "session_id"),
-                    "hostname" => findtag(xml, "hostname"),
-                    )
-                
+                )
                 streams[id]["data"] = 0
                 streams[id]["time"] = Array{Float64}(undef, 0)
                 streams[id]["clock"] = Float64[]
@@ -91,13 +83,7 @@ function read_xdf(filename::AbstractString, sync::Bool=true)
             elseif tag == 6  # StreamFooter
                 xml = String(read(io, len))
                 @debug "    $xml"
-                # Add footer data to stream dictionary
-                streams[id]["first_timestamp"] = findtag(xml, "first_timestamp", Float32)
-                streams[id]["last_timestamp"] = findtag(xml, "last_timestamp", Float32)
-                streams[id]["sample_count"] = findtag(xml, "sample_count", Int)
-                streams[id]["measured_srate"] = findtag(xml, "measured_srate", Float32)
                 streams[id]["footer"] = xml
-                
             else  # unknown chunk type
                 skip(io, len)
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,25 +4,63 @@ using XDF, Downloads, Test
     url = "https://github.com/xdf-modules/example-files/blob/master/minimal.xdf?raw=true"
 
     streams = read_xdf(Downloads.download(url))
+    # Test data stream
+    # header
     @test 0 in keys(streams)
-    @test streams[0]["nchannels"] == 3
     @test streams[0]["name"] == "SendDataC"
-    @test streams[0]["dtype"] == Int16
-    @test streams[0]["srate"] == 10.0
     @test streams[0]["type"] == "EEG"
+    @test streams[0]["nchannels"] == 3
+    @test streams[0]["srate"] == 10.0
+    @test streams[0]["dtype"] == Int16
+    @test isnothing(streams[0]["source_id"])
+    @test isnothing(streams[0]["version"])
+    @test streams[0]["created_at"] == "50942.723319709003"
+    @test streams[0]["uid"] == "xdfwriter_11_int"
+    @test isnothing(streams[0]["session_id"])
+    @test isnothing(streams[0]["hostname"])
+    # data
     @test size(streams[0]["data"]) == (9, 3)
+    data = [192 255 238;
+            12  22  32;
+            13  23  33;
+            14  24  34;
+            15  25  35;
+            12  22  32;
+            13  23  33;
+            14  24  34;
+            15  25  35;]
+    @test streams[0]["data"] == data
+    # footer
+    @test streams[0]["first_timestamp"] == 5.1f0
+    @test streams[0]["last_timestamp"] == 5.9f0
+    @test streams[0]["sample_count"] == 9
+    @test isnothing(streams[0]["measured_srate"]) 
 
+    # Test marker stream
+    # header
     @test 46202862 in keys(streams)
-    @test streams[46202862]["nchannels"] == 1
     @test streams[46202862]["name"] == "SendDataString"
-    @test streams[46202862]["dtype"] == String
-    @test streams[46202862]["srate"] == 10.0
     @test streams[46202862]["type"] == "StringMarker"
+    @test streams[46202862]["nchannels"] == 1
+    @test streams[46202862]["srate"] == 10.0
+    @test streams[46202862]["dtype"] == String
+    @test isnothing(streams[46202862]["source_id"])
+    @test isnothing(streams[46202862]["version"])
+    @test streams[46202862]["created_at"] == "50942.723319709003"
+    @test streams[46202862]["uid"] == "xdfwriter_11_int"
+    @test isnothing(streams[46202862]["session_id"])
+    @test isnothing(streams[46202862]["hostname"])
+    # data
     @test size(streams[46202862]["data"]) == (9, 1)
     @test startswith(streams[46202862]["data"][1, 1], "<?xml version")
     @test endswith(streams[46202862]["data"][1, 1], "</info>")
     @test streams[46202862]["data"][2:end, 1] == ["Hello", "World", "from", "LSL", "Hello",
-                                                  "World", "from", "LSL"]
+                                                "World", "from", "LSL"]
+    # footer
+    @test streams[46202862]["first_timestamp"] == 5.1f0
+    @test streams[46202862]["last_timestamp"] == 5.9f0
+    @test streams[46202862]["sample_count"] == 9
+    @test isnothing(streams[46202862]["measured_srate"]) 
 end
 
 @testset "XDF file with clock resets" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,65 +2,43 @@ using XDF, Downloads, Test
 
 @testset "Minimal XDF file" begin
     url = "https://github.com/xdf-modules/example-files/blob/master/minimal.xdf?raw=true"
-
     streams = read_xdf(Downloads.download(url))
-    # Test data stream
-    # header
+
     @test 0 in keys(streams)
     @test streams[0]["name"] == "SendDataC"
     @test streams[0]["type"] == "EEG"
     @test streams[0]["nchannels"] == 3
     @test streams[0]["srate"] == 10.0
     @test streams[0]["dtype"] == Int16
-    @test isnothing(streams[0]["source_id"])
-    @test isnothing(streams[0]["version"])
-    @test streams[0]["created_at"] == "50942.723319709003"
-    @test streams[0]["uid"] == "xdfwriter_11_int"
-    @test isnothing(streams[0]["session_id"])
-    @test isnothing(streams[0]["hostname"])
-    # data
-    @test size(streams[0]["data"]) == (9, 3)
-    data = [192 255 238;
-            12  22  32;
-            13  23  33;
-            14  24  34;
-            15  25  35;
-            12  22  32;
-            13  23  33;
-            14  24  34;
-            15  25  35;]
-    @test streams[0]["data"] == data
-    # footer
-    @test streams[0]["first_timestamp"] == 5.1f0
-    @test streams[0]["last_timestamp"] == 5.9f0
-    @test streams[0]["sample_count"] == 9
-    @test isnothing(streams[0]["measured_srate"]) 
+    @test startswith(streams[0]["header"], "<?xml version=\"1.0\"?>")
+    @test endswith(streams[0]["header"], "</uid></info>")
+    @test startswith(streams[0]["footer"], "<?xml version=\"1.0\"?>")
+    @test endswith(streams[0]["footer"], "</clock_offsets></info>")
+    @test streams[0]["data"] == [192 255 238
+                                  12  22  32
+                                  13  23  33
+                                  14  24  34
+                                  15  25  35
+                                  12  22  32
+                                  13  23  33
+                                  14  24  34
+                                  15  25  35]
 
-    # Test marker stream
-    # header
     @test 46202862 in keys(streams)
     @test streams[46202862]["name"] == "SendDataString"
     @test streams[46202862]["type"] == "StringMarker"
     @test streams[46202862]["nchannels"] == 1
     @test streams[46202862]["srate"] == 10.0
     @test streams[46202862]["dtype"] == String
-    @test isnothing(streams[46202862]["source_id"])
-    @test isnothing(streams[46202862]["version"])
-    @test streams[46202862]["created_at"] == "50942.723319709003"
-    @test streams[46202862]["uid"] == "xdfwriter_11_int"
-    @test isnothing(streams[46202862]["session_id"])
-    @test isnothing(streams[46202862]["hostname"])
-    # data
+    @test startswith(streams[46202862]["header"], "<?xml version=\"1.0\"?>")
+    @test endswith(streams[46202862]["header"], "</uid></info>")
+    @test startswith(streams[46202862]["footer"], "<?xml version=\"1.0\"?>")
+    @test endswith(streams[46202862]["footer"], "</clock_offsets></info>")
     @test size(streams[46202862]["data"]) == (9, 1)
     @test startswith(streams[46202862]["data"][1, 1], "<?xml version")
     @test endswith(streams[46202862]["data"][1, 1], "</info>")
     @test streams[46202862]["data"][2:end, 1] == ["Hello", "World", "from", "LSL", "Hello",
-                                                "World", "from", "LSL"]
-    # footer
-    @test streams[46202862]["first_timestamp"] == 5.1f0
-    @test streams[46202862]["last_timestamp"] == 5.9f0
-    @test streams[46202862]["sample_count"] == 9
-    @test isnothing(streams[46202862]["measured_srate"]) 
+                                                  "World", "from", "LSL"]
 end
 
 @testset "XDF file with clock resets" begin
@@ -73,6 +51,10 @@ end
     @test streams[1]["dtype"] == String
     @test streams[1]["srate"] == 0.0
     @test streams[1]["type"] == "Markers"
+    @test startswith(streams[1]["header"], "<?xml version=\"1.0\"?>")
+    @test endswith(streams[1]["header"], "<desc />\n</info>\n")
+    @test startswith(streams[1]["footer"], "<?xml version=\"1.0\"?>")
+    @test endswith(streams[1]["footer"], "</clock_offsets></info>")
     @test size(streams[1]["data"]) == (175, 1)
 
     @test 2 in keys(streams)
@@ -81,5 +63,9 @@ end
     @test streams[2]["dtype"] == Float32
     @test streams[2]["srate"] == 100.0
     @test streams[2]["type"] == "EEG"
+    @test startswith(streams[2]["header"], "<?xml version=\"1.0\"?>")
+    @test endswith(streams[2]["header"], "<desc />\n</info>\n")
+    @test startswith(streams[2]["footer"], "<?xml version=\"1.0\"?>")
+    @test endswith(streams[2]["footer"], "</clock_offsets></info>")
     @test size(streams[2]["data"]) == (27815, 8)
 end


### PR DESCRIPTION
Hi!
Here I've added header fields from the XDF spec that were not read into the stream dictionary before. 

The fields are for header (All read as strings):
 - `source_id`
 - `version`
 - `created_at`
 - `uid`
 - `session_id`
 - `hostname`

For the footer:
 - `first_timestamp` as Float32
 - `last_timestamp` as Float32
 - `sample_count` as Int
 - `measured_srate` as Float32

I've also reordered the reading of such fields so that the code resembles the order in which they are presented in the XDF sepec, and added some test.

The header and footer fields are added per stream, and if nothing is found they default to `nothing`(since the `findtag` function already defaults to nothing.

What do you think? Does it make sense? Would you change something?